### PR TITLE
[IDLE-257] feat: 도서 상세보기 내 사용자 리스트 조회 페이지 구현

### DIFF
--- a/app-ui/ios/Podfile
+++ b/app-ui/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '11.0'
+# platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -40,12 +40,5 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
-    target.build_configurations.each do |config|
-      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
-        '$(inherited)',
-        ## dart: PermissionGroup.camera
-        'PERMISSION_CAMERA=1',
-      ]
-    end
   end
 end

--- a/app-ui/ios/Podfile.lock
+++ b/app-ui/ios/Podfile.lock
@@ -42,9 +42,9 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.13.0):
+  - FirebaseCoreExtension (10.14.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.13.0):
+  - FirebaseCoreInternal (10.14.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseCrashlytics (10.12.0):
     - FirebaseCore (~> 10.5)
@@ -54,12 +54,12 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseInstallations (10.13.0):
+  - FirebaseInstallations (10.14.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseSessions (10.13.0):
+  - FirebaseSessions (10.14.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -92,7 +92,7 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.2.3):
+  - GoogleDataTransport (9.2.5):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
@@ -113,24 +113,24 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.3.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
-  - GoogleUtilities/AppDelegateSwizzler (7.11.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.1):
+  - GoogleUtilities/Environment (7.11.5):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.1):
+  - GoogleUtilities/Logger (7.11.5):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.11.1):
+  - GoogleUtilities/MethodSwizzler (7.11.5):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.11.1):
+  - GoogleUtilities/Network (7.11.5):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.1)"
-  - GoogleUtilities/Reachability (7.11.1):
+  - "GoogleUtilities/NSData+zlib (7.11.5)"
+  - GoogleUtilities/Reachability (7.11.5):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.11.1):
+  - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
   - GoogleUtilitiesComponents (1.1.0):
     - GoogleUtilities/Logger
@@ -165,9 +165,9 @@ PODS:
   - nanopb/encode (2.30909.0)
   - permission_handler_apple (9.1.1):
     - Flutter
-  - PromisesObjC (2.2.0)
-  - PromisesSwift (2.2.0):
-    - PromisesObjC (= 2.2.0)
+  - PromisesObjC (2.3.1)
+  - PromisesSwift (2.3.1):
+    - PromisesObjC (= 2.3.1)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -243,19 +243,19 @@ SPEC CHECKSUMS:
   firebase_crashlytics: df144edf7d04ace42beb3a3e29d825bfa49dd04b
   FirebaseAnalytics: 0270389efbe3022b54ec4588862dabec3477ee98
   FirebaseCore: f86a1394906b97ac445ae49c92552a9425831bed
-  FirebaseCoreExtension: ce60f9db46d83944cf444664d6d587474128eeca
-  FirebaseCoreInternal: b342e37cd4f5b4454ec34308f073420e7920858e
+  FirebaseCoreExtension: 976638051b1a46b503afce7ec80277f9161f2040
+  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
   FirebaseCrashlytics: c4d111b7430c49744c74bcc6346ea00868661ac8
-  FirebaseInstallations: b28af1b9f997f1a799efe818c94695a3728c352f
-  FirebaseSessions: 991fb4c20b3505eef125f7cbfa20a5b5b189c2a4
+  FirebaseInstallations: f672b1eda64e6381c21d424a2f680a943fd83f3b
+  FirebaseSessions: f145e7365d36bec0d724c4574a8750e6f82fa6c8
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   flutter_web_auth: c25208760459cec375a3c39f6a8759165ca0fa4d
   GoogleAppMeasurement: 2d800fab85e7848b1e66a6f8ce5bca06c5aad892
-  GoogleDataTransport: f0308f5905a745f94fb91fea9c6cbaf3831cb1bd
+  GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMLKit: 2bd0dc6253c4d4f227aad460f69215a504b2980e
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
-  GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
+  GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
@@ -266,11 +266,11 @@ SPEC CHECKSUMS:
   mobile_scanner: 47056db0c04027ea5f41a716385542da28574662
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
-  PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
-  PromisesSwift: cf9eb58666a43bbe007302226e510b16c1e10959
+  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  PromisesSwift: 28dca69a9c40779916ac2d6985a0192a5cb4a265
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
-PODFILE CHECKSUM: 404e70784e015bfe4a6d9b2a5f397fbbe669c3bd
+PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/app-ui/lib/data/model/book/mybook_detail_response.dart
+++ b/app-ui/lib/data/model/book/mybook_detail_response.dart
@@ -112,6 +112,7 @@ class Book {
   int? id;
   String? title;
   String? description;
+  String? isbn13;
   List<String>? authors;
   List<String>? translators;
   String? publisher;
@@ -122,6 +123,7 @@ class Book {
     this.id,
     this.title,
     this.description,
+    this.isbn13,
     this.authors,
     this.translators,
     this.publisher,
@@ -134,6 +136,7 @@ class Book {
       id: json['id'],
       title: json['title'],
       description: json['description'],
+      isbn13: json['isbn13'],
       authors:
           json['authors'] != null ? List<String>.from(json['authors']) : null,
       translators: json['translators'] != null
@@ -150,6 +153,7 @@ class Book {
     data['id'] = id;
     data['title'] = title;
     data['description'] = description;
+    data['isbn13'] = isbn13;
     data['authors'] = authors;
     data['translators'] = translators;
     data['publisher'] = publisher;

--- a/app-ui/lib/data/model/search/book_detail_user_infos_model.dart
+++ b/app-ui/lib/data/model/search/book_detail_user_infos_model.dart
@@ -1,0 +1,31 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'book_detail_user_infos_model.g.dart';
+
+@JsonSerializable()
+class BookDetailUserInfosModel {
+  final List<UserInfosModel> userInfos;
+
+  BookDetailUserInfosModel({
+    required this.userInfos,
+  });
+
+  factory BookDetailUserInfosModel.fromJson(Map<String, dynamic> json) =>
+      _$BookDetailUserInfosModelFromJson(json);
+}
+
+@JsonSerializable()
+class UserInfosModel {
+  final String userId;
+  final String nickname;
+  final String profileImageUrl;
+
+  UserInfosModel({
+    required this.userId,
+    required this.nickname,
+    required this.profileImageUrl,
+  });
+
+  factory UserInfosModel.fromJson(Map<String, dynamic> json) =>
+      _$UserInfosModelFromJson(json);
+}

--- a/app-ui/lib/data/model/search/book_detail_user_infos_model.g.dart
+++ b/app-ui/lib/data/model/search/book_detail_user_infos_model.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'book_detail_user_infos_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+BookDetailUserInfosModel _$BookDetailUserInfosModelFromJson(
+        Map<String, dynamic> json) =>
+    BookDetailUserInfosModel(
+      userInfos: (json['userInfos'] as List<dynamic>)
+          .map((e) => UserInfosModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$BookDetailUserInfosModelToJson(
+        BookDetailUserInfosModel instance) =>
+    <String, dynamic>{
+      'userInfos': instance.userInfos,
+    };
+
+UserInfosModel _$UserInfosModelFromJson(Map<String, dynamic> json) =>
+    UserInfosModel(
+      userId: json['userId'] as String,
+      nickname: json['nickname'] as String,
+      profileImageUrl: json['profileImageUrl'] as String,
+    );
+
+Map<String, dynamic> _$UserInfosModelToJson(UserInfosModel instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'nickname': instance.nickname,
+      'profileImageUrl': instance.profileImageUrl,
+    };

--- a/app-ui/lib/data/provider/search/search_user_infos_provider.dart
+++ b/app-ui/lib/data/provider/search/search_user_infos_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/model/search/book_detail_user_infos_model.dart';
+import 'package:mybrary/data/repository/search_new_repository.dart';
+
+final searchUserInfoListProvider = Provider<BookDetailUserInfosModel?>((ref) {
+  final state = ref.watch(searchUserInfosProvider);
+
+  if (state is! CommonModel) {
+    return null;
+  }
+
+  return state.data;
+});
+
+final searchUserInfosProvider =
+    StateNotifierProvider<SearchUserInfosStateNotifier, CommonResponseBase>(
+        (ref) {
+  final repo = ref.watch(searchBookServiceRepositoryProvider);
+
+  final notifier = SearchUserInfosStateNotifier(
+    repository: repo,
+  );
+
+  return notifier;
+});
+
+class SearchUserInfosStateNotifier extends StateNotifier<CommonResponseBase> {
+  final SearchNewRepository repository;
+
+  SearchUserInfosStateNotifier({
+    required this.repository,
+  }) : super(CommonResponseLoading());
+
+  void getInterestBookUserInfos(String isbn13) async {
+    if (state is! CommonModel) {
+      state = await repository.getInterestBookUserInfos(isbn13: isbn13);
+    }
+
+    if (state is! CommonModel) {
+      return;
+    }
+  }
+
+  void getReadCompleteBookUserInfos(String isbn13) async {
+    if (state is! CommonModel) {
+      state = await repository.getReadCompleteBookUserInfos(isbn13: isbn13);
+    }
+
+    if (state is! CommonModel) {
+      return;
+    }
+  }
+
+  void getMyBookUserInfos(String isbn13) async {
+    if (state is! CommonModel) {
+      state = await repository.getMyBookUserInfos(isbn13: isbn13);
+    }
+
+    if (state is! CommonModel) {
+      return;
+    }
+  }
+}

--- a/app-ui/lib/data/repository/search_new_repository.dart
+++ b/app-ui/lib/data/repository/search_new_repository.dart
@@ -1,0 +1,38 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/model/search/book_detail_user_infos_model.dart';
+import 'package:mybrary/data/network/api.dart';
+import 'package:mybrary/data/provider/common/dio_provider.dart';
+import 'package:retrofit/http.dart';
+
+part 'search_new_repository.g.dart';
+
+final searchBookServiceRepositoryProvider =
+    Provider<SearchNewRepository>((ref) {
+  final dio = ref.watch(dioProvider);
+
+  final repository = SearchNewRepository(dio, baseUrl: bookServiceUrl);
+
+  return repository;
+});
+
+@RestApi()
+abstract class SearchNewRepository {
+  factory SearchNewRepository(Dio dio, {String baseUrl}) = _SearchNewRepository;
+
+  @GET('/books/{isbn13}/interest/userInfos')
+  Future<CommonModel<BookDetailUserInfosModel>> getInterestBookUserInfos({
+    @Path('isbn13') required String? isbn13,
+  });
+
+  @GET('/books/{isbn13}/read-complete/userInfos')
+  Future<CommonModel<BookDetailUserInfosModel>> getReadCompleteBookUserInfos({
+    @Path('isbn13') required String? isbn13,
+  });
+
+  @GET('/books/{isbn13}/mybook/userInfos')
+  Future<CommonModel<BookDetailUserInfosModel>> getMyBookUserInfos({
+    @Path('isbn13') required String? isbn13,
+  });
+}

--- a/app-ui/lib/data/repository/search_new_repository.g.dart
+++ b/app-ui/lib/data/repository/search_new_repository.g.dart
@@ -1,0 +1,117 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_new_repository.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+
+class _SearchNewRepository implements SearchNewRepository {
+  _SearchNewRepository(
+    this._dio, {
+    this.baseUrl,
+  });
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<CommonModel<BookDetailUserInfosModel>> getInterestBookUserInfos(
+      {isbn13}) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<CommonModel<BookDetailUserInfosModel>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/books/${isbn13}/interest/userInfos',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = CommonModel<BookDetailUserInfosModel>.fromJson(
+      _result.data!,
+      (json) => BookDetailUserInfosModel.fromJson(json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
+  @override
+  Future<CommonModel<BookDetailUserInfosModel>> getReadCompleteBookUserInfos(
+      {isbn13}) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<CommonModel<BookDetailUserInfosModel>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/books/${isbn13}/read-complete/userInfos',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = CommonModel<BookDetailUserInfosModel>.fromJson(
+      _result.data!,
+      (json) => BookDetailUserInfosModel.fromJson(json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
+  @override
+  Future<CommonModel<BookDetailUserInfosModel>> getMyBookUserInfos(
+      {isbn13}) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<CommonModel<BookDetailUserInfosModel>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/books/${isbn13}/mybook/userInfos',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = CommonModel<BookDetailUserInfosModel>.fromJson(
+      _result.data!,
+      (json) => BookDetailUserInfosModel.fromJson(json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+}

--- a/app-ui/lib/res/constants/enum.dart
+++ b/app-ui/lib/res/constants/enum.dart
@@ -15,3 +15,9 @@ enum UserInterestType {
   second,
   third,
 }
+
+enum SearchDetailUserInfosType {
+  interest,
+  readComplete,
+  myBook,
+}

--- a/app-ui/lib/res/constants/enum.dart
+++ b/app-ui/lib/res/constants/enum.dart
@@ -19,5 +19,5 @@ enum UserInterestType {
 enum SearchDetailUserInfosType {
   interest,
   readComplete,
-  myBook,
+  holder,
 }

--- a/app-ui/lib/res/constants/style.dart
+++ b/app-ui/lib/res/constants/style.dart
@@ -166,7 +166,7 @@ const interestDescriptionStyle = TextStyle(
 const followNicknameStyle = TextStyle(
   color: commonBlackColor,
   fontSize: 15.0,
-  fontWeight: FontWeight.w400,
+  fontWeight: FontWeight.w500,
 );
 
 const followButtonTextStyle = TextStyle(

--- a/app-ui/lib/ui/mybook/mybook_detail/components/mybook_detail_more.dart
+++ b/app-ui/lib/ui/mybook/mybook_detail/components/mybook_detail_more.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
+
+class MyBookDetailMore extends StatelessWidget {
+  final String isbn13;
+
+  const MyBookDetailMore({
+    required this.isbn13,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => SearchDetailScreen(isbn13: isbn13),
+            ),
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Column(
+            children: [
+              const SizedBox(height: 10.0),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const Text(
+                    '도서 상세보기',
+                    style: commonSubTitleStyle,
+                  ),
+                  SizedBox(
+                    child: SvgPicture.asset(
+                      'assets/svg/icon/right_arrow.svg',
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20.0),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app-ui/lib/ui/mybook/mybook_detail/components/mybook_detail_more.dart
+++ b/app-ui/lib/ui/mybook/mybook_detail/components/mybook_detail_more.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
 
 class MyBookDetailMore extends StatelessWidget {
   final String isbn13;
@@ -27,20 +26,8 @@ class MyBookDetailMore extends StatelessWidget {
           child: Column(
             children: [
               const SizedBox(height: 10.0),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text(
-                    '도서 상세보기',
-                    style: commonSubTitleStyle,
-                  ),
-                  SizedBox(
-                    child: SvgPicture.asset(
-                      'assets/svg/icon/right_arrow.svg',
-                    ),
-                  ),
-                ],
+              commonSubTitle(
+                title: '도서 상세보기',
               ),
               const SizedBox(height: 20.0),
             ],

--- a/app-ui/lib/ui/mybook/mybook_detail/mybook_detail_screen.dart
+++ b/app-ui/lib/ui/mybook/mybook_detail/mybook_detail_screen.dart
@@ -18,6 +18,7 @@ import 'package:mybrary/ui/common/components/data_error.dart';
 import 'package:mybrary/ui/common/layout/default_layout.dart';
 import 'package:mybrary/ui/common/layout/root_tab.dart';
 import 'package:mybrary/ui/mybook/mybook_detail/components/mybook_detail_header.dart';
+import 'package:mybrary/ui/mybook/mybook_detail/components/mybook_detail_more.dart';
 import 'package:mybrary/ui/mybook/mybook_detail/components/mybook_detail_record.dart';
 import 'package:mybrary/ui/mybook/mybook_detail/components/mybook_detail_review.dart';
 import 'package:mybrary/ui/mybook/mybook_detail/components/mybook_edit_review.dart';
@@ -270,6 +271,10 @@ class _MyBookDetailScreenState extends State<MyBookDetailScreen> {
                         reviewId: myBookReviewData.id!,
                         userId: widget.userId,
                       ),
+                    _myBookDetailDivider(),
+                    MyBookDetailMore(
+                      isbn13: myBookInfo.isbn13!,
+                    ),
                     SliverToBoxAdapter(
                       child: SizedBox(
                         height: widget.userId == null ? 70.0 : 30.0,

--- a/app-ui/lib/ui/profile/components/profile_intro.dart
+++ b/app-ui/lib/ui/profile/components/profile_intro.dart
@@ -4,6 +4,7 @@ import 'package:mybrary/data/model/profile/my_interests_response.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/profile/my_badge/my_badge_screen.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
 
 class ProfileIntro extends StatelessWidget {
   final String? introduction;
@@ -54,21 +55,7 @@ class ProfileIntro extends StatelessWidget {
             onTap: () {
               onTapMyInterests();
             },
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                const Text(
-                  '마이 관심사',
-                  style: commonSubTitleStyle,
-                ),
-                SizedBox(
-                  child: SvgPicture.asset(
-                    'assets/svg/icon/right_arrow.svg',
-                  ),
-                ),
-              ],
-            ),
+            child: commonSubTitle(title: '마이 관심사'),
           ),
           const SizedBox(height: 12.0),
           Text(
@@ -86,21 +73,7 @@ class ProfileIntro extends StatelessWidget {
                 ),
               );
             },
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                const Text(
-                  '마이 뱃지',
-                  style: commonSubTitleStyle,
-                ),
-                SizedBox(
-                  child: SvgPicture.asset(
-                    'assets/svg/icon/right_arrow.svg',
-                  ),
-                ),
-              ],
-            ),
+            child: commonSubTitle(title: '마이 뱃지'),
           ),
           const SizedBox(height: 12.0),
           SizedBox(

--- a/app-ui/lib/ui/search/components/search_all_user_list.dart
+++ b/app-ui/lib/ui/search/components/search_all_user_list.dart
@@ -4,12 +4,11 @@ import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/data/repository/search_repository.dart';
 import 'package:mybrary/ui/common/components/error_page.dart';
 import 'package:mybrary/ui/common/components/single_data_error.dart';
-import 'package:mybrary/ui/common/layout/root_tab.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
-import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 import 'package:mybrary/ui/search/components/search_loading.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_info.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_layout.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
 
 class SearchAllUserList extends StatefulWidget {
   const SearchAllUserList({super.key});
@@ -68,26 +67,12 @@ class _SearchAllUserListState extends State<SearchAllUserList> {
 
                   return InkWell(
                     onTap: () {
-                      if (_userId != searchedUser.userId) {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => UserProfileScreen(
-                              userId: searchedUser.userId!,
-                              nickname: searchedUser.nickname!,
-                            ),
-                          ),
-                        );
-                      }
-                      if (_userId == searchedUser.userId!) {
-                        Navigator.of(context).pushAndRemoveUntil(
-                          MaterialPageRoute(
-                            builder: (_) => const RootTab(
-                              tapIndex: 3,
-                            ),
-                          ),
-                          (route) => false,
-                        );
-                      }
+                      nextToUserProfile(
+                        context: context,
+                        myUserId: _userId,
+                        userId: searchedUser.userId!,
+                        nickname: searchedUser.nickname!,
+                      );
                     },
                     child: SearchUserLayout(
                       children: [

--- a/app-ui/lib/ui/search/components/search_all_user_list.dart
+++ b/app-ui/lib/ui/search/components/search_all_user_list.dart
@@ -67,7 +67,7 @@ class _SearchAllUserListState extends State<SearchAllUserList> {
 
                   return InkWell(
                     onTap: () {
-                      nextToUserProfile(
+                      moveToUserProfile(
                         context: context,
                         myUserId: _userId,
                         userId: searchedUser.userId!,

--- a/app-ui/lib/ui/search/search_book_list/components/search_user_info.dart
+++ b/app-ui/lib/ui/search/search_book_list/components/search_user_info.dart
@@ -15,6 +15,7 @@ class SearchUserInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
       children: [
         CircleAvatar(
           radius: 20.0,

--- a/app-ui/lib/ui/search/search_book_list/components/search_user_layout.dart
+++ b/app-ui/lib/ui/search/search_book_list/components/search_user_layout.dart
@@ -15,9 +15,8 @@ class SearchUserLayout extends StatelessWidget {
         horizontal: 16.0,
         vertical: 8.0,
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        crossAxisAlignment: CrossAxisAlignment.center,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: children,
       ),
     );

--- a/app-ui/lib/ui/search/search_book_list/search_book_list.dart
+++ b/app-ui/lib/ui/search/search_book_list/search_book_list.dart
@@ -9,13 +9,12 @@ import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/components/error_page.dart';
 import 'package:mybrary/ui/common/components/single_data_error.dart';
-import 'package:mybrary/ui/common/layout/root_tab.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
-import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 import 'package:mybrary/ui/search/components/search_loading.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_book_list_info.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_info.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_layout.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
 
 class SearchBookList extends StatefulWidget {
   final String searchKeyword;
@@ -412,26 +411,12 @@ class _SearchBookListState extends State<SearchBookList>
 
             return InkWell(
               onTap: () {
-                if (_userId != searchedUser.userId) {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => UserProfileScreen(
-                        userId: searchedUser.userId!,
-                        nickname: searchedUser.nickname!,
-                      ),
-                    ),
-                  );
-                }
-                if (_userId == searchedUser.userId!) {
-                  Navigator.of(context).pushAndRemoveUntil(
-                    MaterialPageRoute(
-                      builder: (_) => const RootTab(
-                        tapIndex: 3,
-                      ),
-                    ),
-                    (route) => false,
-                  );
-                }
+                nextToUserProfile(
+                  context: context,
+                  myUserId: _userId,
+                  userId: searchedUser.userId!,
+                  nickname: searchedUser.nickname!,
+                );
               },
               child: SearchUserLayout(
                 children: [

--- a/app-ui/lib/ui/search/search_book_list/search_book_list.dart
+++ b/app-ui/lib/ui/search/search_book_list/search_book_list.dart
@@ -411,7 +411,7 @@ class _SearchBookListState extends State<SearchBookList>
 
             return InkWell(
               onTap: () {
-                nextToUserProfile(
+                moveToUserProfile(
                   context: context,
                   myUserId: _userId,
                   userId: searchedUser.userId!,

--- a/app-ui/lib/ui/search/search_detail/components/book_detail_header.dart
+++ b/app-ui/lib/ui/search/search_detail/components/book_detail_header.dart
@@ -185,9 +185,24 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                   ),
                 ),
                 const SizedBox(height: 8.0),
-                Text(
-                  '${widget.readCount} 명',
-                  style: bookStatusCountStyle,
+                InkWell(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => SearchDetailUserInfosScreen(
+                          title: '완독했어요',
+                          isbn13: widget.isbn13,
+                          userCount: widget.readCount,
+                          type: SearchDetailUserInfosType.readComplete,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Text(
+                    '${widget.readCount} 명',
+                    style: bookStatusCountStyle,
+                  ),
                 ),
               ],
             ),
@@ -208,9 +223,24 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                   ),
                 ),
                 const SizedBox(height: 8.0),
-                Text(
-                  '${widget.newRegistered == true ? widget.holderCount + 1 : widget.holderCount} 명',
-                  style: bookStatusCountStyle,
+                InkWell(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => SearchDetailUserInfosScreen(
+                          title: '소장하고있어요',
+                          isbn13: widget.isbn13,
+                          userCount: widget.holderCount,
+                          type: SearchDetailUserInfosType.holder,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Text(
+                    '${widget.newRegistered == true ? widget.holderCount + 1 : widget.holderCount} 명',
+                    style: bookStatusCountStyle,
+                  ),
                 ),
               ],
             ),

--- a/app-ui/lib/ui/search/search_detail/components/book_detail_header.dart
+++ b/app-ui/lib/ui/search/search_detail/components/book_detail_header.dart
@@ -169,12 +169,24 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                 ),
               ],
             ),
-            bookStatusColumn(
-              padding: 36.0,
-              children: [
-                InkWell(
-                  onTap: () async {},
-                  child: Column(
+            InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => SearchDetailUserInfosScreen(
+                      title: '완독했어요',
+                      isbn13: widget.isbn13,
+                      userCount: widget.readCount,
+                      type: SearchDetailUserInfosType.readComplete,
+                    ),
+                  ),
+                );
+              },
+              child: bookStatusColumn(
+                padding: 36.0,
+                children: [
+                  Column(
                     children: [
                       SvgPicture.asset(
                         'assets/svg/icon/small/${widget.completed ? 'read_green.svg' : 'read.svg'}',
@@ -183,36 +195,33 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                       const Text('완독했어요', style: bookStatusStyle),
                     ],
                   ),
-                ),
-                const SizedBox(height: 8.0),
-                InkWell(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => SearchDetailUserInfosScreen(
-                          title: '완독했어요',
-                          isbn13: widget.isbn13,
-                          userCount: widget.readCount,
-                          type: SearchDetailUserInfosType.readComplete,
-                        ),
-                      ),
-                    );
-                  },
-                  child: Text(
+                  const SizedBox(height: 8.0),
+                  Text(
                     '${widget.readCount} 명',
                     style: bookStatusCountStyle,
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-            bookStatusColumn(
-              padding: 24.0,
-              lastBox: true,
-              children: [
-                InkWell(
-                  onTap: () async {},
-                  child: Column(
+            InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => SearchDetailUserInfosScreen(
+                      title: '소장하고있어요',
+                      isbn13: widget.isbn13,
+                      userCount: widget.holderCount,
+                      type: SearchDetailUserInfosType.holder,
+                    ),
+                  ),
+                );
+              },
+              child: bookStatusColumn(
+                padding: 24.0,
+                lastBox: true,
+                children: [
+                  Column(
                     children: [
                       SvgPicture.asset(
                         'assets/svg/icon/small/${widget.newRegistered || widget.registered ? 'holder_green.svg' : 'holder.svg'}',
@@ -221,28 +230,13 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                       const Text('소장하고있어요', style: bookStatusStyle),
                     ],
                   ),
-                ),
-                const SizedBox(height: 8.0),
-                InkWell(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => SearchDetailUserInfosScreen(
-                          title: '소장하고있어요',
-                          isbn13: widget.isbn13,
-                          userCount: widget.holderCount,
-                          type: SearchDetailUserInfosType.holder,
-                        ),
-                      ),
-                    );
-                  },
-                  child: Text(
+                  const SizedBox(height: 8.0),
+                  Text(
                     '${widget.newRegistered == true ? widget.holderCount + 1 : widget.holderCount} 명',
                     style: bookStatusCountStyle,
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ],
         ),

--- a/app-ui/lib/ui/search/search_detail/components/book_detail_header.dart
+++ b/app-ui/lib/ui/search/search_detail/components/book_detail_header.dart
@@ -5,8 +5,10 @@ import 'package:mybrary/data/model/search/book_search_detail_response.dart';
 import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/data/repository/book_repository.dart';
 import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/enum.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/mybook/interest_book_list/interest_book_list_screen.dart';
+import 'package:mybrary/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart';
 import 'package:mybrary/utils/logics/book_utils.dart';
 import 'package:mybrary/utils/logics/common_utils.dart';
 
@@ -146,9 +148,24 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                   ),
                 ),
                 const SizedBox(height: 8.0),
-                Text(
-                  '$_newInterestCount 명',
-                  style: bookStatusCountStyle,
+                InkWell(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => SearchDetailUserInfosScreen(
+                          title: '읽고싶어요',
+                          isbn13: widget.isbn13,
+                          userCount: widget.interestCount,
+                          type: SearchDetailUserInfosType.interest,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Text(
+                    '$_newInterestCount 명',
+                    style: bookStatusCountStyle,
+                  ),
                 ),
               ],
             ),

--- a/app-ui/lib/ui/search/search_detail_review/components/review_item.dart
+++ b/app-ui/lib/ui/search/search_detail_review/components/review_item.dart
@@ -53,7 +53,7 @@ class _ReviewItemState extends State<ReviewItem> {
             children: [
               InkWell(
                 onTap: () {
-                  nextToUserProfile(
+                  moveToUserProfile(
                     context: context,
                     myUserId: _userId,
                     userId: widget.review.userId!,

--- a/app-ui/lib/ui/search/search_detail_review/components/review_item.dart
+++ b/app-ui/lib/ui/search/search_detail_review/components/review_item.dart
@@ -3,9 +3,8 @@ import 'package:mybrary/data/model/search/book_detail_review_response.dart';
 import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
-import 'package:mybrary/ui/common/layout/root_tab.dart';
-import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 import 'package:mybrary/utils/logics/book_utils.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
 
 class ReviewItem extends StatefulWidget {
   final MyBookReviewList review;
@@ -54,26 +53,12 @@ class _ReviewItemState extends State<ReviewItem> {
             children: [
               InkWell(
                 onTap: () {
-                  if (_userId != widget.review.userId) {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => UserProfileScreen(
-                          userId: widget.review.userId!,
-                          nickname: widget.review.userNickname!,
-                        ),
-                      ),
-                    );
-                  }
-                  if (_userId == widget.review.userId!) {
-                    Navigator.of(context).pushAndRemoveUntil(
-                      MaterialPageRoute(
-                        builder: (_) => const RootTab(
-                          tapIndex: 3,
-                        ),
-                      ),
-                      (route) => false,
-                    );
-                  }
+                  nextToUserProfile(
+                    context: context,
+                    myUserId: _userId,
+                    userId: widget.review.userId!,
+                    nickname: widget.review.userNickname!,
+                  );
                 },
                 child: Row(
                   children: [

--- a/app-ui/lib/ui/search/search_detail_review/components/review_item.dart
+++ b/app-ui/lib/ui/search/search_detail_review/components/review_item.dart
@@ -3,6 +3,8 @@ import 'package:mybrary/data/model/search/book_detail_review_response.dart';
 import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/layout/root_tab.dart';
+import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 import 'package:mybrary/utils/logics/book_utils.dart';
 
 class ReviewItem extends StatefulWidget {
@@ -50,50 +52,74 @@ class _ReviewItemState extends State<ReviewItem> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: [
-                  CircleAvatar(
-                    radius: 16.0,
-                    backgroundColor: greyACACAC,
-                    backgroundImage: NetworkImage(
-                      widget.review.userPictureUrl!,
-                    ),
-                  ),
-                  const SizedBox(width: 12.0),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(left: 2.0),
-                        child: Text(
-                          widget.review.userNickname!,
-                          style: commonSubMediumStyle.copyWith(
-                            fontSize: 14.0,
-                          ),
+              InkWell(
+                onTap: () {
+                  if (_userId != widget.review.userId) {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => UserProfileScreen(
+                          userId: widget.review.userId!,
+                          nickname: widget.review.userNickname!,
                         ),
                       ),
-                      const SizedBox(height: 2.0),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: [
-                          starRatingRow(
-                            starRating: widget.review.starRating!,
-                            width: 16.0,
-                            height: 16.0,
-                          ),
-                          const SizedBox(width: 8.0),
-                          Text(
-                            '$year.$month.$day',
-                            style: commonSubRegularStyle.copyWith(
-                              fontSize: 12.0,
-                              color: grey777777,
+                    );
+                  }
+                  if (_userId == widget.review.userId!) {
+                    Navigator.of(context).pushAndRemoveUntil(
+                      MaterialPageRoute(
+                        builder: (_) => const RootTab(
+                          tapIndex: 3,
+                        ),
+                      ),
+                      (route) => false,
+                    );
+                  }
+                },
+                child: Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 16.0,
+                      backgroundColor: greyACACAC,
+                      backgroundImage: NetworkImage(
+                        widget.review.userPictureUrl!,
+                      ),
+                    ),
+                    const SizedBox(width: 12.0),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(left: 2.0),
+                          child: Text(
+                            widget.review.userNickname!,
+                            style: commonSubMediumStyle.copyWith(
+                              fontSize: 14.0,
                             ),
                           ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
+                        ),
+                        const SizedBox(height: 2.0),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: [
+                            starRatingRow(
+                              starRating: widget.review.starRating!,
+                              width: 16.0,
+                              height: 16.0,
+                            ),
+                            const SizedBox(width: 8.0),
+                            Text(
+                              '$year.$month.$day',
+                              style: commonSubRegularStyle.copyWith(
+                                fontSize: 12.0,
+                                color: grey777777,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
               if (_userId == widget.review.userId)
                 InkWell(

--- a/app-ui/lib/ui/search/search_detail_user_infos/components/user_count.dart
+++ b/app-ui/lib/ui/search/search_detail_user_infos/components/user_count.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/res/constants/style.dart';
+
+class UserCount extends StatelessWidget {
+  final int userCount;
+
+  const UserCount({
+    required this.userCount,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Row(
+          children: [
+            Text(
+              '총 $userCount명',
+              style: commonSubBoldStyle.copyWith(
+                fontSize: 15.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
+++ b/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
@@ -6,9 +6,7 @@ import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/res/constants/enum.dart';
 import 'package:mybrary/ui/common/components/circular_loading.dart';
 import 'package:mybrary/ui/common/components/error_page.dart';
-import 'package:mybrary/ui/common/layout/root_tab.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
-import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_info.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_layout.dart';
 import 'package:mybrary/ui/search/search_detail_user_infos/components/user_count.dart';
@@ -102,26 +100,12 @@ class _SearchDetailUserInfosScreenState
                 children: [
                   InkWell(
                     onTap: () {
-                      if (_userId != userInfos[index].userId) {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => UserProfileScreen(
-                              userId: userInfos[index].userId!,
-                              nickname: userInfos[index].nickname!,
-                            ),
-                          ),
-                        );
-                      }
-                      if (_userId == userInfos[index].userId!) {
-                        Navigator.of(context).pushAndRemoveUntil(
-                          MaterialPageRoute(
-                            builder: (_) => const RootTab(
-                              tapIndex: 3,
-                            ),
-                          ),
-                          (route) => false,
-                        );
-                      }
+                      nextToUserProfile(
+                        context: context,
+                        myUserId: _userId,
+                        userId: userInfos[index].userId,
+                        nickname: userInfos[index].nickname,
+                      );
                     },
                     child: SearchUserInfo(
                       nickname: userInfos[index].nickname!,

--- a/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
+++ b/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
@@ -117,7 +117,11 @@ class _SearchDetailUserInfosScreenState
               childCount: userInfos.length,
             ),
           ),
-          const SliverToBoxAdapter(child: SizedBox(height: 30.0)),
+          const SliverToBoxAdapter(
+            child: SizedBox(
+              height: 30.0,
+            ),
+          ),
         ],
       ),
     );

--- a/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
+++ b/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mybrary/data/model/common/common_model.dart';
 import 'package:mybrary/data/provider/search/search_user_infos_provider.dart';
+import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/res/constants/enum.dart';
 import 'package:mybrary/ui/common/components/circular_loading.dart';
 import 'package:mybrary/ui/common/components/error_page.dart';
+import 'package:mybrary/ui/common/layout/root_tab.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
+import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_info.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_user_layout.dart';
 import 'package:mybrary/ui/search/search_detail_user_infos/components/user_count.dart';
@@ -32,6 +35,8 @@ class SearchDetailUserInfosScreen extends ConsumerStatefulWidget {
 
 class _SearchDetailUserInfosScreenState
     extends ConsumerState<SearchDetailUserInfosScreen> {
+  final _userId = UserState.userId;
+
   @override
   void initState() {
     super.initState();
@@ -39,17 +44,17 @@ class _SearchDetailUserInfosScreenState
     switch (widget.type) {
       case SearchDetailUserInfosType.interest:
         ref
-            .read(searchUserInfosProvider.notifier)
+            .refresh(searchUserInfosProvider.notifier)
             .getInterestBookUserInfos(widget.isbn13);
         break;
       case SearchDetailUserInfosType.readComplete:
         ref
-            .read(searchUserInfosProvider.notifier)
+            .refresh(searchUserInfosProvider.notifier)
             .getReadCompleteBookUserInfos(widget.isbn13);
         break;
-      case SearchDetailUserInfosType.myBook:
+      case SearchDetailUserInfosType.holder:
         ref
-            .read(searchUserInfosProvider.notifier)
+            .refresh(searchUserInfosProvider.notifier)
             .getMyBookUserInfos(widget.isbn13);
         break;
     }
@@ -95,9 +100,33 @@ class _SearchDetailUserInfosScreenState
             delegate: SliverChildBuilderDelegate(
               (context, index) => SearchUserLayout(
                 children: [
-                  SearchUserInfo(
-                    nickname: userInfos[index].nickname!,
-                    profileImageUrl: userInfos[index].profileImageUrl!,
+                  InkWell(
+                    onTap: () {
+                      if (_userId != userInfos[index].userId) {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => UserProfileScreen(
+                              userId: userInfos[index].userId!,
+                              nickname: userInfos[index].nickname!,
+                            ),
+                          ),
+                        );
+                      }
+                      if (_userId == userInfos[index].userId!) {
+                        Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(
+                            builder: (_) => const RootTab(
+                              tapIndex: 3,
+                            ),
+                          ),
+                          (route) => false,
+                        );
+                      }
+                    },
+                    child: SearchUserInfo(
+                      nickname: userInfos[index].nickname!,
+                      profileImageUrl: userInfos[index].profileImageUrl!,
+                    ),
                   ),
                 ],
               ),

--- a/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
+++ b/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/provider/search/search_user_infos_provider.dart';
+import 'package:mybrary/res/constants/enum.dart';
+import 'package:mybrary/ui/common/components/circular_loading.dart';
+import 'package:mybrary/ui/common/components/error_page.dart';
+import 'package:mybrary/ui/common/layout/subpage_layout.dart';
+import 'package:mybrary/ui/search/search_book_list/components/search_user_info.dart';
+import 'package:mybrary/ui/search/search_book_list/components/search_user_layout.dart';
+import 'package:mybrary/ui/search/search_detail_user_infos/components/user_count.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
+
+class SearchDetailUserInfosScreen extends ConsumerStatefulWidget {
+  final String title;
+  final String isbn13;
+  final int userCount;
+  final SearchDetailUserInfosType type;
+
+  const SearchDetailUserInfosScreen({
+    required this.title,
+    required this.isbn13,
+    required this.userCount,
+    required this.type,
+    super.key,
+  });
+
+  @override
+  ConsumerState<SearchDetailUserInfosScreen> createState() =>
+      _SearchDetailUserInfosScreenState();
+}
+
+class _SearchDetailUserInfosScreenState
+    extends ConsumerState<SearchDetailUserInfosScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    switch (widget.type) {
+      case SearchDetailUserInfosType.interest:
+        ref
+            .read(searchUserInfosProvider.notifier)
+            .getInterestBookUserInfos(widget.isbn13);
+        break;
+      case SearchDetailUserInfosType.readComplete:
+        ref
+            .read(searchUserInfosProvider.notifier)
+            .getReadCompleteBookUserInfos(widget.isbn13);
+        break;
+      case SearchDetailUserInfosType.myBook:
+        ref
+            .read(searchUserInfosProvider.notifier)
+            .getMyBookUserInfos(widget.isbn13);
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final userInfos = [];
+
+    final state = ref.watch(searchUserInfoListProvider);
+
+    if (state == null || state is CommonResponseLoading) {
+      return _initUserInfosLayout(child: const CircularLoading());
+    }
+
+    if (state is CommonResponseError) {
+      return _initUserInfosLayout(
+        child: const Column(
+          children: [
+            ErrorPage(
+              errorMessage: '서비스에 문제가 있어요.\n잠시만 기다려 주세요 !',
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (state is! CommonResponseLoading) {
+      userInfos.addAll(state.userInfos);
+    }
+
+    return _initUserInfosLayout(
+      child: CustomScrollView(
+        physics: const BouncingScrollPhysics(
+          parent: AlwaysScrollableScrollPhysics(),
+        ),
+        slivers: [
+          commonSliverAppBar(
+            appBarTitle: widget.title,
+          ),
+          UserCount(userCount: widget.userCount),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => SearchUserLayout(
+                children: [
+                  SearchUserInfo(
+                    nickname: userInfos[index].nickname!,
+                    profileImageUrl: userInfos[index].profileImageUrl!,
+                  ),
+                ],
+              ),
+              childCount: userInfos.length,
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 30.0)),
+        ],
+      ),
+    );
+  }
+
+  SubPageLayout _initUserInfosLayout({
+    required Widget child,
+  }) {
+    return SubPageLayout(
+      child: child,
+    );
+  }
+}

--- a/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
+++ b/app-ui/lib/ui/search/search_detail_user_infos/search_detail_user_infos_screen.dart
@@ -100,7 +100,7 @@ class _SearchDetailUserInfosScreenState
                 children: [
                   InkWell(
                     onTap: () {
-                      nextToUserProfile(
+                      moveToUserProfile(
                         context: context,
                         myUserId: _userId,
                         userId: userInfos[index].userId,

--- a/app-ui/lib/utils/logics/common_utils.dart
+++ b/app-ui/lib/utils/logics/common_utils.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/layout/root_tab.dart';
+import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
 
 Widget loadingIndicator() {
   return CircularProgressIndicator(
@@ -178,4 +180,32 @@ Widget commonSliverDivider() {
       color: greyF1F2F5,
     ),
   );
+}
+
+void nextToUserProfile({
+  required BuildContext context,
+  required String myUserId,
+  required String userId,
+  required String nickname,
+}) {
+  if (myUserId != userId) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => UserProfileScreen(
+          userId: userId,
+          nickname: nickname,
+        ),
+      ),
+    );
+  }
+  if (myUserId == userId) {
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(
+        builder: (_) => const RootTab(
+          tapIndex: 3,
+        ),
+      ),
+      (route) => false,
+    );
+  }
 }

--- a/app-ui/lib/utils/logics/common_utils.dart
+++ b/app-ui/lib/utils/logics/common_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/layout/root_tab.dart';
@@ -208,4 +209,24 @@ void nextToUserProfile({
       (route) => false,
     );
   }
+}
+
+Row commonSubTitle({
+  required String title,
+}) {
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    crossAxisAlignment: CrossAxisAlignment.center,
+    children: [
+      Text(
+        title,
+        style: commonSubTitleStyle,
+      ),
+      SizedBox(
+        child: SvgPicture.asset(
+          'assets/svg/icon/right_arrow.svg',
+        ),
+      ),
+    ],
+  );
 }

--- a/app-ui/lib/utils/logics/common_utils.dart
+++ b/app-ui/lib/utils/logics/common_utils.dart
@@ -183,7 +183,7 @@ Widget commonSliverDivider() {
   );
 }
 
-void nextToUserProfile({
+void moveToUserProfile({
   required BuildContext context,
   required String myUserId,
   required String userId,

--- a/app-ui/lib/utils/logics/common_utils.dart
+++ b/app-ui/lib/utils/logics/common_utils.dart
@@ -161,3 +161,21 @@ void commonBottomSheet({
     },
   );
 }
+
+Widget commonDivider() {
+  return const Divider(
+    height: 1,
+    thickness: 1,
+    color: greyF1F2F5,
+  );
+}
+
+Widget commonSliverDivider() {
+  return const SliverToBoxAdapter(
+    child: Divider(
+      height: 1,
+      thickness: 1,
+      color: greyF1F2F5,
+    ),
+  );
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 도서 상세보기 / 마이북 상세보기

<div>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/4ad46143-8f2b-458b-a7a7-8b937a83234e" alt="도서 상세보기 내 사용자 리스트 조회" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/e105bd84-1742-4c7c-80d9-f9978b437232" alt="도서 상세보기 내 리뷰 사용자 프로필 조회" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/d34ceeec-3efb-4045-b0a2-874fcc0b5b51" alt="마이북 상세 내 도서 상세로 이동" width="260" height="580"/>
</div>

<br>

- 도서 상세보기 내 읽고싶어요/완독했어요/소장하고있어요 사용자 목록 조회
- 추가로 도서 상세보기 내 리뷰 목록에서 사용자 클릭 시 프로필로 이동
  - 본인 클릭 시 본인 프로필로 이동
- 사용자 의견에 따라 마이북 상세 페이지에서 도서 상세로 이동하는 버튼 추가

<br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

- 사용자 의견을 반영하였으며, 추가로 리뷰 목록에서 사용자 프로필 이동을 추가하였습니다.
- 추후 다른 곳에서도 공통 컴포넌트를 사용할 것 같아, enum으로 사용자 리스트 조회를 관리합니다.

<br>
