### PR TITLE
[IDLE-258] feat: 오늘 마이브러리에 등록된 책 조회 페이지 구현

### DIFF
--- a/app-ui/lib/data/model/common/books_params.dart
+++ b/app-ui/lib/data/model/common/books_params.dart
@@ -4,14 +4,18 @@ part 'books_params.g.dart';
 
 @JsonSerializable()
 class BooksParams {
-  final String type;
+  final String? type;
   final String? page;
   final int? categoryId;
+  final String? start;
+  final String? end;
 
   const BooksParams({
-    required this.type,
+    this.type,
     this.page,
     this.categoryId,
+    this.start,
+    this.end,
   });
 
   factory BooksParams.fromJson(Map<String, dynamic> json) =>

--- a/app-ui/lib/data/model/common/books_params.g.dart
+++ b/app-ui/lib/data/model/common/books_params.g.dart
@@ -7,9 +7,11 @@ part of 'books_params.dart';
 // **************************************************************************
 
 BooksParams _$BooksParamsFromJson(Map<String, dynamic> json) => BooksParams(
-      type: json['type'] as String,
+      type: json['type'] as String?,
       page: json['page'] as String?,
       categoryId: json['categoryId'] as int?,
+      start: json['start'] as String?,
+      end: json['end'] as String?,
     );
 
 Map<String, dynamic> _$BooksParamsToJson(BooksParams instance) =>
@@ -17,4 +19,6 @@ Map<String, dynamic> _$BooksParamsToJson(BooksParams instance) =>
       'type': instance.type,
       'page': instance.page,
       'categoryId': instance.categoryId,
+      'start': instance.start,
+      'end': instance.end,
     };

--- a/app-ui/lib/data/model/home/today_registered_book_count_model.dart
+++ b/app-ui/lib/data/model/home/today_registered_book_count_model.dart
@@ -13,3 +13,41 @@ class TodayRegisteredBookCountModel {
   factory TodayRegisteredBookCountModel.fromJson(Map<String, dynamic> json) =>
       _$TodayRegisteredBookCountModelFromJson(json);
 }
+
+@JsonSerializable()
+class TodayRegisteredBookListModel {
+  final int totalCount;
+  final List<MyBookRegisteredListModel> myBookRegisteredList;
+
+  TodayRegisteredBookListModel({
+    required this.totalCount,
+    required this.myBookRegisteredList,
+  });
+
+  factory TodayRegisteredBookListModel.fromJson(Map<String, dynamic> json) =>
+      _$TodayRegisteredBookListModelFromJson(json);
+}
+
+@JsonSerializable()
+class MyBookRegisteredListModel {
+  final String userId;
+  final String nickname;
+  final String profileImageUrl;
+  final String title;
+  final String thumbnailUrl;
+  final String isbn13;
+  final String? registeredAt;
+
+  MyBookRegisteredListModel({
+    required this.userId,
+    required this.nickname,
+    required this.profileImageUrl,
+    required this.title,
+    required this.thumbnailUrl,
+    required this.isbn13,
+    required this.registeredAt,
+  });
+
+  factory MyBookRegisteredListModel.fromJson(Map<String, dynamic> json) =>
+      _$MyBookRegisteredListModelFromJson(json);
+}

--- a/app-ui/lib/data/model/home/today_registered_book_count_model.g.dart
+++ b/app-ui/lib/data/model/home/today_registered_book_count_model.g.dart
@@ -17,3 +17,44 @@ Map<String, dynamic> _$TodayRegisteredBookCountModelToJson(
     <String, dynamic>{
       'count': instance.count,
     };
+
+TodayRegisteredBookListModel _$TodayRegisteredBookListModelFromJson(
+        Map<String, dynamic> json) =>
+    TodayRegisteredBookListModel(
+      totalCount: json['totalCount'] as int,
+      myBookRegisteredList: (json['myBookRegisteredList'] as List<dynamic>)
+          .map((e) =>
+              MyBookRegisteredListModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$TodayRegisteredBookListModelToJson(
+        TodayRegisteredBookListModel instance) =>
+    <String, dynamic>{
+      'totalCount': instance.totalCount,
+      'myBookRegisteredList': instance.myBookRegisteredList,
+    };
+
+MyBookRegisteredListModel _$MyBookRegisteredListModelFromJson(
+        Map<String, dynamic> json) =>
+    MyBookRegisteredListModel(
+      userId: json['userId'] as String,
+      nickname: json['nickname'] as String,
+      profileImageUrl: json['profileImageUrl'] as String,
+      title: json['title'] as String,
+      thumbnailUrl: json['thumbnailUrl'] as String,
+      isbn13: json['isbn13'] as String,
+      registeredAt: json['registeredAt'] as String?,
+    );
+
+Map<String, dynamic> _$MyBookRegisteredListModelToJson(
+        MyBookRegisteredListModel instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'nickname': instance.nickname,
+      'profileImageUrl': instance.profileImageUrl,
+      'title': instance.title,
+      'thumbnailUrl': instance.thumbnailUrl,
+      'isbn13': instance.isbn13,
+      'registeredAt': instance.registeredAt,
+    };

--- a/app-ui/lib/data/provider/home/home_book_count_list_provider.dart
+++ b/app-ui/lib/data/provider/home/home_book_count_list_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/model/home/today_registered_book_count_model.dart';
+import 'package:mybrary/data/repository/home_new_repository.dart';
+
+final homeBookCountListProvider =
+    Provider<TodayRegisteredBookListModel?>((ref) {
+  final state = ref.watch(homeBookServiceProvider);
+
+  if (state is! CommonModel) {
+    return null;
+  }
+
+  return state.data;
+});
+
+final homeBookServiceProvider =
+    StateNotifierProvider<HomeBookCountListStateNotifier, CommonResponseBase>(
+        (ref) {
+  final repo = ref.watch(homeBookServiceRepositoryProvider);
+
+  final notifier = HomeBookCountListStateNotifier(
+    repository: repo,
+  );
+
+  return notifier;
+});
+
+class HomeBookCountListStateNotifier extends StateNotifier<CommonResponseBase> {
+  final HomeNewRepository repository;
+
+  HomeBookCountListStateNotifier({
+    required this.repository,
+  }) : super(CommonResponseLoading());
+
+  void getTodayRegisteredBookList() async {
+    if (state is! CommonModel) {
+      state = await repository.getTodayRegisteredBookList();
+    }
+
+    if (state is! CommonModel) {
+      return;
+    }
+  }
+}

--- a/app-ui/lib/data/repository/home_new_repository.dart
+++ b/app-ui/lib/data/repository/home_new_repository.dart
@@ -31,6 +31,14 @@ final homeUserServiceRepositoryProvider = Provider<HomeNewRepository>((ref) {
 abstract class HomeNewRepository {
   factory HomeNewRepository(Dio dio, {String baseUrl}) = _HomeNewRepository;
 
+  @GET('/mybooks')
+  Future<CommonModel<TodayRegisteredBookListModel>> getTodayRegisteredBookList({
+    @Queries() BooksParams? booksParams = const BooksParams(
+      start: '',
+      end: '',
+    ),
+  });
+
   @GET('/mybooks/today-registration-count')
   Future<CommonModel<TodayRegisteredBookCountModel>>
       getTodayRegisteredBookCount();

--- a/app-ui/lib/data/repository/home_new_repository.g.dart
+++ b/app-ui/lib/data/repository/home_new_repository.g.dart
@@ -19,6 +19,36 @@ class _HomeNewRepository implements HomeNewRepository {
   String? baseUrl;
 
   @override
+  Future<CommonModel<TodayRegisteredBookListModel>> getTodayRegisteredBookList(
+      {booksParams = const BooksParams(start: '', end: '')}) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.addAll(booksParams?.toJson() ?? <String, dynamic>{});
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<CommonModel<TodayRegisteredBookListModel>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/mybooks',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = CommonModel<TodayRegisteredBookListModel>.fromJson(
+      _result.data!,
+      (json) =>
+          TodayRegisteredBookListModel.fromJson(json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
+  @override
   Future<CommonModel<TodayRegisteredBookCountModel>>
       getTodayRegisteredBookCount() async {
     const _extra = <String, dynamic>{};

--- a/app-ui/lib/res/constants/style.dart
+++ b/app-ui/lib/res/constants/style.dart
@@ -233,14 +233,16 @@ const categoryCircularTextStyle = TextStyle(
 
 const todayRegisteredBookNickname = TextStyle(
   color: primaryColor,
-  fontSize: 12.0,
+  fontSize: 13.0,
   fontWeight: FontWeight.w500,
+  height: 1.5,
 );
 
 const todayRegisteredBookIntroduction = TextStyle(
   color: grey262626,
-  fontSize: 12.0,
+  fontSize: 13.0,
   fontWeight: FontWeight.w400,
+  height: 1.5,
 );
 
 // book search page style

--- a/app-ui/lib/res/constants/style.dart
+++ b/app-ui/lib/res/constants/style.dart
@@ -231,6 +231,18 @@ const categoryCircularTextStyle = TextStyle(
   fontWeight: FontWeight.w400,
 );
 
+const todayRegisteredBookNickname = TextStyle(
+  color: primaryColor,
+  fontSize: 12.0,
+  fontWeight: FontWeight.w500,
+);
+
+const todayRegisteredBookIntroduction = TextStyle(
+  color: grey262626,
+  fontSize: 12.0,
+  fontWeight: FontWeight.w400,
+);
+
 // book search page style
 const searchBookTitleStyle = TextStyle(
   color: grey262626,

--- a/app-ui/lib/ui/home/components/home_book_count.dart
+++ b/app-ui/lib/ui/home/components/home_book_count.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/home/components/home_book_count_list.dart';
 
 class HomeBookCount extends StatelessWidget {
   final int todayRegisteredBookCount;
@@ -26,41 +27,50 @@ class HomeBookCount extends StatelessWidget {
                   '오늘 마이브러리에 등록된 책!',
                   style: todayRegisteredBookTextStyle,
                 ),
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8.0,
-                        vertical: 2.0,
+                InkWell(
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const HomeBookCountList(),
                       ),
-                      decoration: ShapeDecoration(
-                        gradient: const LinearGradient(
-                          begin: Alignment(0.00, -1.00),
-                          end: Alignment(0, 1),
-                          colors: [
-                            homeTodayRegisteredBookColorTop,
-                            homeTodayRegisteredBookColorCenter,
-                            homeTodayRegisteredBookColorBottom,
-                          ],
+                    );
+                  },
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8.0,
+                          vertical: 2.0,
                         ),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(30.0),
+                        decoration: ShapeDecoration(
+                          gradient: const LinearGradient(
+                            begin: Alignment(0.00, -1.00),
+                            end: Alignment(0, 1),
+                            colors: [
+                              homeTodayRegisteredBookColorTop,
+                              homeTodayRegisteredBookColorCenter,
+                              homeTodayRegisteredBookColorBottom,
+                            ],
+                          ),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(30.0),
+                          ),
+                        ),
+                        child: Text(
+                          todayRegisteredBookCount.toString().padLeft(6, '0'),
+                          style: todayRegisteredBookTextStyle.copyWith(
+                            color: commonWhiteColor,
+                            letterSpacing: 2.0,
+                          ),
                         ),
                       ),
-                      child: Text(
-                        todayRegisteredBookCount.toString().padLeft(6, '0'),
-                        style: todayRegisteredBookTextStyle.copyWith(
-                          color: commonWhiteColor,
-                          letterSpacing: 2.0,
-                        ),
+                      const SizedBox(width: 4.0),
+                      const Text(
+                        '권',
+                        style: todayRegisteredBookTextStyle,
                       ),
-                    ),
-                    const SizedBox(width: 4.0),
-                    const Text(
-                      '권',
-                      style: todayRegisteredBookTextStyle,
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/app-ui/lib/ui/home/components/home_book_count_list.dart
+++ b/app-ui/lib/ui/home/components/home_book_count_list.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/model/home/today_registered_book_count_model.dart';
+import 'package:mybrary/data/provider/home/home_book_count_list_provider.dart';
+import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/components/circular_loading.dart';
+import 'package:mybrary/ui/common/components/error_page.dart';
+import 'package:mybrary/ui/common/layout/subpage_layout.dart';
+import 'package:mybrary/utils/logics/common_utils.dart';
+
+class HomeBookCountList extends ConsumerStatefulWidget {
+  const HomeBookCountList({super.key});
+
+  @override
+  ConsumerState<HomeBookCountList> createState() => _HomeBookCountListState();
+}
+
+class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
+  @override
+  void initState() {
+    super.initState();
+
+    ref.refresh(homeBookServiceProvider.notifier).getTodayRegisteredBookList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final homeBookCountList = ref.watch(homeBookCountListProvider);
+
+    if (homeBookCountList == null) {
+      return _initLayout(
+        child: const CircularLoading(),
+      );
+    }
+
+    if (homeBookCountList is CommonResponseError) {
+      return _initLayout(
+        child: const ErrorPage(
+          errorMessage: '서비스에 문제가 있어요.\n잠시만 기다려 주세요 !',
+        ),
+      );
+    }
+
+    return _initLayout(
+      child: ListView.builder(
+        physics: const BouncingScrollPhysics(
+          parent: AlwaysScrollableScrollPhysics(),
+        ),
+        itemCount: homeBookCountList.totalCount,
+        itemBuilder: (context, index) {
+          MyBookRegisteredListModel book =
+              homeBookCountList.myBookRegisteredList[index];
+
+          return InkWell(
+            onTap: () {},
+            child: Column(
+              children: [
+                if (index != 0) const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16.0,
+                    vertical: 4.0,
+                  ),
+                  child: Row(
+                    children: [
+                      Stack(
+                        clipBehavior: Clip.none,
+                        children: [
+                          Container(
+                            width: 70,
+                            height: 100,
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: greyF1F2F5,
+                                width: 1,
+                              ),
+                              image: DecorationImage(
+                                image: NetworkImage(
+                                  book.thumbnailUrl,
+                                ),
+                                onError: (exception, stackTrace) => Image.asset(
+                                  'assets/img/logo/mybrary.png',
+                                  fit: BoxFit.fill,
+                                ),
+                                fit: BoxFit.fill,
+                              ),
+                            ),
+                          ),
+                          Positioned(
+                            bottom: -10,
+                            right: -10,
+                            child: CircleAvatar(
+                              radius: 22.0,
+                              backgroundColor: greyACACAC,
+                              backgroundImage: NetworkImage(
+                                book.profileImageUrl,
+                              ),
+                            ),
+                          )
+                        ],
+                      ),
+                      const SizedBox(width: 20.0),
+                      SizedBox(
+                        width: MediaQuery.of(context).size.width * 0.6,
+                        height: 100,
+                        child: Stack(
+                          children: [
+                            Positioned(
+                              top: 0,
+                              child: Text(
+                                book.title,
+                                style: commonSubMediumStyle.copyWith(
+                                  fontSize: 14.0,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            if (book.nickname.length > 10)
+                              Positioned(
+                                bottom: 0,
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: userDescription(book: book),
+                                ),
+                              )
+                            else
+                              Positioned(
+                                bottom: 0,
+                                child: Row(
+                                  children: userDescription(book: book),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                commonDivider(
+                  dividerHeight: 4,
+                  dividerThickness: 4,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _initLayout({
+    required Widget child,
+  }) {
+    return SubPageLayout(
+      appBarTitle: '실시간 마이북 등록',
+      child: child,
+    );
+  }
+
+  List<Widget> userDescription({
+    required MyBookRegisteredListModel book,
+  }) {
+    return [
+      Text(
+        book.nickname,
+        style: todayRegisteredBookNickname,
+      ),
+      const Text(
+        '님이 마이북에 도서를 추가했어요!',
+        style: todayRegisteredBookIntroduction,
+      ),
+    ];
+  }
+}

--- a/app-ui/lib/ui/home/components/home_book_count_list.dart
+++ b/app-ui/lib/ui/home/components/home_book_count_list.dart
@@ -56,8 +56,9 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
           MyBookRegisteredListModel book =
               homeBookCountList.myBookRegisteredList[index];
 
-          String bookTitle =
-              book.title.length > 30 ? book.title.substring(0, 30) : book.title;
+          String bookTitle = book.title.length > 40
+              ? '${book.title.substring(0, 40)}...'
+              : book.title;
 
           return Column(
             children: [

--- a/app-ui/lib/ui/home/components/home_book_count_list.dart
+++ b/app-ui/lib/ui/home/components/home_book_count_list.dart
@@ -46,111 +46,44 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
       );
     }
 
-    return _initLayout(
-      child: ListView.builder(
-        physics: const BouncingScrollPhysics(
-          parent: AlwaysScrollableScrollPhysics(),
-        ),
-        itemCount: homeBookCountList.totalCount,
-        itemBuilder: (context, index) {
-          MyBookRegisteredListModel book =
-              homeBookCountList.myBookRegisteredList[index];
+    return RefreshIndicator(
+      color: commonWhiteColor,
+      backgroundColor: primaryColor,
+      onRefresh: () {
+        return Future.delayed(
+          const Duration(seconds: 1),
+          () {
+            ref
+                .refresh(homeBookServiceProvider.notifier)
+                .getTodayRegisteredBookList();
+          },
+        );
+      },
+      child: _initLayout(
+        child: ListView.builder(
+          physics: const BouncingScrollPhysics(
+            parent: AlwaysScrollableScrollPhysics(),
+          ),
+          itemCount: homeBookCountList.totalCount,
+          itemBuilder: (context, index) {
+            MyBookRegisteredListModel book =
+                homeBookCountList.myBookRegisteredList[index];
 
-          String bookTitle = book.title.length > 40
-              ? '${book.title.substring(0, 40)}...'
-              : book.title;
+            String bookTitle = book.title.length > 40
+                ? '${book.title.substring(0, 40)}...'
+                : book.title;
 
-          return Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(
-                  left: 12.0,
-                ),
-                child: Row(
-                  children: [
-                    Stack(
-                      clipBehavior: Clip.none,
-                      children: [
-                        InkWell(
-                          onTap: () {
-                            moveToBookDetail(
-                              context: context,
-                              isbn13: book.isbn13,
-                            );
-                          },
-                          child: Container(
-                            width: 70,
-                            height: 100,
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: greyF1F2F5,
-                                width: 1,
-                              ),
-                              image: DecorationImage(
-                                image: NetworkImage(
-                                  book.thumbnailUrl,
-                                ),
-                                onError: (exception, stackTrace) => Image.asset(
-                                  'assets/img/logo/mybrary.png',
-                                  fit: BoxFit.fill,
-                                ),
-                                fit: BoxFit.fill,
-                              ),
-                            ),
-                          ),
-                        ),
-                        Positioned(
-                          bottom: -10,
-                          right: -10,
-                          child: InkWell(
-                            onTap: () {
-                              moveToUserProfile(
-                                context: context,
-                                myUserId: _userId,
-                                userId: book.userId,
-                                nickname: book.nickname,
-                              );
-                            },
-                            child: CircleAvatar(
-                              radius: 22.0,
-                              backgroundColor: greyACACAC,
-                              backgroundImage: NetworkImage(
-                                book.profileImageUrl,
-                              ),
-                            ),
-                          ),
-                        )
-                      ],
-                    ),
-                    const SizedBox(width: 20.0),
-                    SizedBox(
-                      width: MediaQuery.of(context).size.width * 0.7,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+            return Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(
+                    left: 12.0,
+                  ),
+                  child: Row(
+                    children: [
+                      Stack(
+                        clipBehavior: Clip.none,
                         children: [
-                          InkWell(
-                            onTap: () {
-                              moveToUserProfile(
-                                context: context,
-                                myUserId: _userId,
-                                userId: book.userId,
-                                nickname: book.nickname,
-                              );
-                            },
-                            child: Text.rich(
-                              TextSpan(
-                                text: book.nickname,
-                                style: todayRegisteredBookNickname,
-                                children: const [
-                                  TextSpan(
-                                    text: '님이',
-                                    style: todayRegisteredBookIntroduction,
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 4.0),
                           InkWell(
                             onTap: () {
                               moveToBookDetail(
@@ -158,32 +91,114 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
                                 isbn13: book.isbn13,
                               );
                             },
-                            child: Text(
-                              '「 $bookTitle 」',
-                              style: commonSubBoldStyle.copyWith(
-                                fontSize: 15.0,
+                            child: Container(
+                              width: 70,
+                              height: 100,
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: greyF1F2F5,
+                                  width: 1,
+                                ),
+                                image: DecorationImage(
+                                  image: NetworkImage(
+                                    book.thumbnailUrl,
+                                  ),
+                                  onError: (exception, stackTrace) =>
+                                      Image.asset(
+                                    'assets/img/logo/mybrary.png',
+                                    fit: BoxFit.fill,
+                                  ),
+                                  fit: BoxFit.fill,
+                                ),
                               ),
                             ),
                           ),
-                          const SizedBox(height: 4.0),
-                          const Text(
-                            '을(를) 마이북에 추가했어요!',
-                            style: todayRegisteredBookIntroduction,
-                          ),
+                          Positioned(
+                            bottom: -10,
+                            right: -10,
+                            child: InkWell(
+                              onTap: () {
+                                moveToUserProfile(
+                                  context: context,
+                                  myUserId: _userId,
+                                  userId: book.userId,
+                                  nickname: book.nickname,
+                                );
+                              },
+                              child: CircleAvatar(
+                                radius: 22.0,
+                                backgroundColor: greyACACAC,
+                                backgroundImage: NetworkImage(
+                                  book.profileImageUrl,
+                                ),
+                              ),
+                            ),
+                          )
                         ],
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: 20.0),
+                      SizedBox(
+                        width: MediaQuery.of(context).size.width * 0.7,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            InkWell(
+                              onTap: () {
+                                moveToUserProfile(
+                                  context: context,
+                                  myUserId: _userId,
+                                  userId: book.userId,
+                                  nickname: book.nickname,
+                                );
+                              },
+                              child: Text.rich(
+                                TextSpan(
+                                  text: book.nickname,
+                                  style: todayRegisteredBookNickname,
+                                  children: const [
+                                    TextSpan(
+                                      text: '님이',
+                                      style: todayRegisteredBookIntroduction,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: 4.0),
+                            InkWell(
+                              onTap: () {
+                                moveToBookDetail(
+                                  context: context,
+                                  isbn13: book.isbn13,
+                                );
+                              },
+                              child: Text(
+                                '「 $bookTitle 」',
+                                style: commonSubBoldStyle.copyWith(
+                                  fontSize: 15.0,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: 4.0),
+                            const Text(
+                              '을(를) 마이북에 추가했어요!',
+                              style: todayRegisteredBookIntroduction,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(height: 24),
-              commonDivider(
-                dividerThickness: 5,
-              ),
-              const SizedBox(height: 12),
-            ],
-          );
-        },
+                const SizedBox(height: 24),
+                commonDivider(
+                  dividerThickness: 5,
+                ),
+                const SizedBox(height: 12),
+              ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/app-ui/lib/ui/home/components/home_book_count_list.dart
+++ b/app-ui/lib/ui/home/components/home_book_count_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mybrary/data/model/common/common_model.dart';
 import 'package:mybrary/data/model/home/today_registered_book_count_model.dart';
 import 'package:mybrary/data/provider/home/home_book_count_list_provider.dart';
+import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/components/circular_loading.dart';
@@ -18,6 +19,8 @@ class HomeBookCountList extends ConsumerStatefulWidget {
 }
 
 class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
+  final _userId = UserState.userId;
+
   @override
   void initState() {
     super.initState();
@@ -53,22 +56,28 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
           MyBookRegisteredListModel book =
               homeBookCountList.myBookRegisteredList[index];
 
-          return InkWell(
-            onTap: () {},
-            child: Column(
-              children: [
-                if (index != 0) const SizedBox(height: 16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
-                    vertical: 4.0,
-                  ),
-                  child: Row(
-                    children: [
-                      Stack(
-                        clipBehavior: Clip.none,
-                        children: [
-                          Container(
+          String bookTitle =
+              book.title.length > 30 ? book.title.substring(0, 30) : book.title;
+
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: 12.0,
+                ),
+                child: Row(
+                  children: [
+                    Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        InkWell(
+                          onTap: () {
+                            moveToBookDetail(
+                              context: context,
+                              isbn13: book.isbn13,
+                            );
+                          },
+                          child: Container(
                             width: 70,
                             height: 100,
                             decoration: BoxDecoration(
@@ -88,9 +97,19 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
                               ),
                             ),
                           ),
-                          Positioned(
-                            bottom: -10,
-                            right: -10,
+                        ),
+                        Positioned(
+                          bottom: -10,
+                          right: -10,
+                          child: InkWell(
+                            onTap: () {
+                              moveToUserProfile(
+                                context: context,
+                                myUserId: _userId,
+                                userId: book.userId,
+                                nickname: book.nickname,
+                              );
+                            },
                             child: CircleAvatar(
                               radius: 22.0,
                               backgroundColor: greyACACAC,
@@ -98,54 +117,70 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
                                 book.profileImageUrl,
                               ),
                             ),
-                          )
-                        ],
-                      ),
-                      const SizedBox(width: 20.0),
-                      SizedBox(
-                        width: MediaQuery.of(context).size.width * 0.6,
-                        height: 100,
-                        child: Stack(
-                          children: [
-                            Positioned(
-                              top: 0,
-                              child: Text(
-                                book.title,
-                                style: commonSubMediumStyle.copyWith(
-                                  fontSize: 14.0,
-                                ),
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
+                          ),
+                        )
+                      ],
+                    ),
+                    const SizedBox(width: 20.0),
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width * 0.7,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          InkWell(
+                            onTap: () {
+                              moveToUserProfile(
+                                context: context,
+                                myUserId: _userId,
+                                userId: book.userId,
+                                nickname: book.nickname,
+                              );
+                            },
+                            child: Text.rich(
+                              TextSpan(
+                                text: book.nickname,
+                                style: todayRegisteredBookNickname,
+                                children: const [
+                                  TextSpan(
+                                    text: '님이',
+                                    style: todayRegisteredBookIntroduction,
+                                  ),
+                                ],
                               ),
                             ),
-                            if (book.nickname.length > 10)
-                              Positioned(
-                                bottom: 0,
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: userDescription(book: book),
-                                ),
-                              )
-                            else
-                              Positioned(
-                                bottom: 0,
-                                child: Row(
-                                  children: userDescription(book: book),
-                                ),
+                          ),
+                          const SizedBox(height: 4.0),
+                          InkWell(
+                            onTap: () {
+                              moveToBookDetail(
+                                context: context,
+                                isbn13: book.isbn13,
+                              );
+                            },
+                            child: Text(
+                              '「 $bookTitle 」',
+                              style: commonSubBoldStyle.copyWith(
+                                fontSize: 15.0,
                               ),
-                          ],
-                        ),
+                            ),
+                          ),
+                          const SizedBox(height: 4.0),
+                          const Text(
+                            '을(를) 마이북에 추가했어요!',
+                            style: todayRegisteredBookIntroduction,
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 16),
-                commonDivider(
-                  dividerHeight: 4,
-                  dividerThickness: 4,
-                ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 24),
+              commonDivider(
+                dividerThickness: 5,
+              ),
+              const SizedBox(height: 12),
+            ],
           );
         },
       ),
@@ -156,23 +191,8 @@ class _HomeBookCountListState extends ConsumerState<HomeBookCountList> {
     required Widget child,
   }) {
     return SubPageLayout(
-      appBarTitle: '실시간 마이북 등록',
+      appBarTitle: '오늘 마이북에 담긴 책',
       child: child,
     );
-  }
-
-  List<Widget> userDescription({
-    required MyBookRegisteredListModel book,
-  }) {
-    return [
-      Text(
-        book.nickname,
-        style: todayRegisteredBookNickname,
-      ),
-      const Text(
-        '님이 마이북에 도서를 추가했어요!',
-        style: todayRegisteredBookIntroduction,
-      ),
-    ];
   }
 }

--- a/app-ui/lib/ui/mybook/mybook_detail/mybook_detail_screen.dart
+++ b/app-ui/lib/ui/mybook/mybook_detail/mybook_detail_screen.dart
@@ -401,7 +401,7 @@ class _MyBookDetailScreenState extends State<MyBookDetailScreen> {
                         _myBookRecordInput(
                           context: context,
                           controller: _meaningTagQuoteController,
-                          hintText: '내 삶을 돌아보게 만든 책',
+                          hintText: '내 삶을 돌아보게 만든 책 (최대 15자까지)',
                         ),
                         const SizedBox(height: 16.0),
                         const Text(
@@ -550,7 +550,7 @@ class _MyBookDetailScreenState extends State<MyBookDetailScreen> {
   }) {
     return TextFormField(
       controller: controller,
-      maxLength: 20,
+      maxLength: 15,
       style: commonSubMediumStyle,
       scrollPadding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom,

--- a/app-ui/lib/utils/logics/common_utils.dart
+++ b/app-ui/lib/utils/logics/common_utils.dart
@@ -6,6 +6,7 @@ import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/layout/root_tab.dart';
 import 'package:mybrary/ui/profile/user_profile/user_profile_screen.dart';
+import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
 
 Widget loadingIndicator() {
   return CircularProgressIndicator(
@@ -212,6 +213,17 @@ void moveToUserProfile({
       (route) => false,
     );
   }
+}
+
+void moveToBookDetail({
+  required BuildContext context,
+  required String isbn13,
+}) {
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (_) => SearchDetailScreen(isbn13: isbn13),
+    ),
+  );
 }
 
 Row commonSubTitle({

--- a/app-ui/lib/utils/logics/common_utils.dart
+++ b/app-ui/lib/utils/logics/common_utils.dart
@@ -165,10 +165,13 @@ void commonBottomSheet({
   );
 }
 
-Widget commonDivider() {
-  return const Divider(
-    height: 1,
-    thickness: 1,
+Widget commonDivider({
+  double? dividerHeight,
+  double? dividerThickness,
+}) {
+  return Divider(
+    height: dividerHeight ?? 1,
+    thickness: dividerThickness ?? 1,
     color: greyF1F2F5,
   );
 }


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 오늘 마이브러리에 담긴 책 페이지

<div>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/dcd1845c-bf8b-43dd-a21d-4dc63ff35079" alt="오늘마이북에등록된책페이지" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/56a8ead2-153a-4869-b4c8-9d49b72b73c0" alt="페이지이동" width="260" height="580"/>
</div>

<br>

오늘 마이북에 담은 사용자와 도서 목록
- 오늘 마이북에 책을 담은 사용자와 책 제목 목록화 UI 구현
- 프로필 사진 또는 닉네임 클릭 시 사용자 페이지로 이동
- 책 사진 또는 책 제목 클릭 시 책 상세 페이지로 이동
- 해당 페이지 내 새로고침 스크롤 적용

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

- 닉네임, 제목, 내용 각 한 줄씩 맞추다보니 작은 화면에서는 닉네임에 대해 약간 밀림 현상이 있습니다.
  - UI 상 조금 안 좋을 수 있는데, 닉네임 길이를 조금 줄인다던지 하는 방법을 생각해볼 수 있을 것 같습니다.
- 마이북 상세에서 '나에게 이 책은' 필드 값이 20자를 맞추는 경우 화면 밖으로 초과하는 이슈가 존재했습니다.
  - ...더보기 또는 필드 길이 제한 2가지 방법을 고안하였습니다.
  - 이 중 UI 상 더 나은 방법이 필드 길이 제한이라 생각되어 기존 20자에서 15자 제한으로 임시 수정하였습니다.
  - 인풋의 hint 텍스트에 최대 15자까지를 추가했습니다.

<br>
