### PR TITLE
[IDLE-281] feat: 설정페이지 내 소셜 로그인 이메일 정보 조회 연동

### DIFF
--- a/app-ui/lib/data/model/profile/profile_email_model.dart
+++ b/app-ui/lib/data/model/profile/profile_email_model.dart
@@ -1,0 +1,15 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'profile_email_model.g.dart';
+
+@JsonSerializable()
+class ProfileEmailModel {
+  final String email;
+
+  ProfileEmailModel({
+    required this.email,
+  });
+
+  factory ProfileEmailModel.fromJson(Map<String, dynamic> json) =>
+      _$ProfileEmailModelFromJson(json);
+}

--- a/app-ui/lib/data/model/profile/profile_email_model.g.dart
+++ b/app-ui/lib/data/model/profile/profile_email_model.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile_email_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ProfileEmailModel _$ProfileEmailModelFromJson(Map<String, dynamic> json) =>
+    ProfileEmailModel(
+      email: json['email'] as String,
+    );
+
+Map<String, dynamic> _$ProfileEmailModelToJson(ProfileEmailModel instance) =>
+    <String, dynamic>{
+      'email': instance.email,
+    };

--- a/app-ui/lib/data/provider/profile/profile_email_provider.dart
+++ b/app-ui/lib/data/provider/profile/profile_email_provider.dart
@@ -4,8 +4,8 @@ import 'package:mybrary/data/model/profile/profile_email_model.dart';
 import 'package:mybrary/data/provider/user_provider.dart';
 import 'package:mybrary/data/repository/profile_new_repository.dart';
 
-final profileEmailProvider = Provider<ProfileEmailModel?>((ref) {
-  final state = ref.watch(profileProvider);
+final userEmailProvider = Provider<ProfileEmailModel?>((ref) {
+  final state = ref.watch(profileEmailProvider);
 
   if (state is! CommonModel) {
     return null;
@@ -14,7 +14,7 @@ final profileEmailProvider = Provider<ProfileEmailModel?>((ref) {
   return state.data;
 });
 
-final profileProvider =
+final profileEmailProvider =
     StateNotifierProvider<ProfileEmailStateNotifier, CommonResponseBase>((ref) {
   final repo = ref.watch(profileRepositoryProvider);
 
@@ -39,6 +39,10 @@ class ProfileEmailStateNotifier extends StateNotifier<CommonResponseBase> {
 
     if (state is! CommonModel) {
       return;
+    }
+
+    if (state is CommonResponseError) {
+      throw Exception('이메일 정보를 가져올 수 없습니다.');
     }
   }
 }

--- a/app-ui/lib/data/provider/profile/profile_email_provider.dart
+++ b/app-ui/lib/data/provider/profile/profile_email_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/model/profile/profile_email_model.dart';
+import 'package:mybrary/data/provider/user_provider.dart';
+import 'package:mybrary/data/repository/profile_new_repository.dart';
+
+final profileEmailProvider = Provider<ProfileEmailModel?>((ref) {
+  final state = ref.watch(profileProvider);
+
+  if (state is! CommonModel) {
+    return null;
+  }
+
+  return state.data;
+});
+
+final profileProvider =
+    StateNotifierProvider<ProfileEmailStateNotifier, CommonResponseBase>((ref) {
+  final repo = ref.watch(profileRepositoryProvider);
+
+  final notifier = ProfileEmailStateNotifier(
+    repository: repo,
+  );
+
+  return notifier;
+});
+
+class ProfileEmailStateNotifier extends StateNotifier<CommonResponseBase> {
+  final ProfileNewRepository repository;
+
+  ProfileEmailStateNotifier({
+    required this.repository,
+  }) : super(CommonResponseLoading());
+
+  void getUserEmail() async {
+    if (state is! CommonModel) {
+      state = await repository.getUserEmail(userId: UserState.userId);
+    }
+
+    if (state is! CommonModel) {
+      return;
+    }
+  }
+}

--- a/app-ui/lib/data/repository/profile_new_repository.dart
+++ b/app-ui/lib/data/repository/profile_new_repository.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart' hide Headers;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/model/common/common_model.dart';
+import 'package:mybrary/data/model/profile/profile_email_model.dart';
+import 'package:mybrary/data/network/api.dart';
+import 'package:mybrary/data/provider/common/dio_provider.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'profile_new_repository.g.dart';
+
+final profileRepositoryProvider = Provider<ProfileNewRepository>((ref) {
+  final dio = ref.watch(dioProvider);
+
+  final repository = ProfileNewRepository(dio, baseUrl: userServiceUrl);
+
+  return repository;
+});
+
+@RestApi()
+abstract class ProfileNewRepository {
+  factory ProfileNewRepository(Dio dio, {String baseUrl}) =
+      _ProfileNewRepository;
+
+  @GET('/users/{userId}/profile/email')
+  Future<CommonModel<ProfileEmailModel>> getUserEmail({
+    @Path('userId') required String? userId,
+  });
+}

--- a/app-ui/lib/data/repository/profile_new_repository.g.dart
+++ b/app-ui/lib/data/repository/profile_new_repository.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile_new_repository.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+
+class _ProfileNewRepository implements ProfileNewRepository {
+  _ProfileNewRepository(
+    this._dio, {
+    this.baseUrl,
+  });
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<CommonModel<ProfileEmailModel>> getUserEmail({userId}) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<CommonModel<ProfileEmailModel>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/users/${userId}/profile/email',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = CommonModel<ProfileEmailModel>.fromJson(
+      _result.data!,
+      (json) => ProfileEmailModel.fromJson(json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+}

--- a/app-ui/lib/ui/setting/components/login_info.dart
+++ b/app-ui/lib/ui/setting/components/login_info.dart
@@ -17,12 +17,12 @@ class _LoginInfoState extends ConsumerState<LoginInfo> {
   void initState() {
     super.initState();
 
-    ref.read(profileProvider.notifier).getUserEmail();
+    ref.read(profileEmailProvider.notifier).getUserEmail();
   }
 
   @override
   Widget build(BuildContext context) {
-    final profileEmail = ref.watch(profileEmailProvider);
+    final profileEmail = ref.watch(userEmailProvider);
 
     if (profileEmail == null) {
       return const SubPageLayout(

--- a/app-ui/lib/ui/setting/components/login_info.dart
+++ b/app-ui/lib/ui/setting/components/login_info.dart
@@ -1,34 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mybrary/data/provider/profile/profile_email_provider.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/components/circular_loading.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
 
-class LoginInfo extends StatefulWidget {
+class LoginInfo extends ConsumerStatefulWidget {
   const LoginInfo({super.key});
 
   @override
-  State<LoginInfo> createState() => _LoginInfoState();
+  ConsumerState<LoginInfo> createState() => _LoginInfoState();
 }
 
-class _LoginInfoState extends State<LoginInfo> {
+class _LoginInfoState extends ConsumerState<LoginInfo> {
+  @override
+  void initState() {
+    super.initState();
+
+    ref.read(profileProvider.notifier).getUserEmail();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const SubPageLayout(
+    final profileEmail = ref.watch(profileEmailProvider);
+
+    if (profileEmail == null) {
+      return const SubPageLayout(
+        appBarTitle: '로그인 정보',
+        child: CircularLoading(),
+      );
+    }
+
+    return SubPageLayout(
       appBarTitle: '로그인 정보',
       child: Padding(
-        padding: EdgeInsets.all(16.0),
+        padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
+            const Text(
               '현재 로그인한 소셜 로그인 정보입니다.',
               style: commonSubRegularStyle,
             ),
-            SizedBox(
-              height: 16.0,
-            ),
-            Text(
+            const SizedBox(height: 16.0),
+            const Text(
               '이메일',
               style: commonSubMediumStyle,
+            ),
+            const SizedBox(height: 12.0),
+            Text(
+              profileEmail.email,
+              style: commonSubRegularStyle,
             ),
           ],
         ),


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 설정페이지 내 소셜 로그인 이메일 표시 (AOS/IOS)

<div>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/af69fef7-f86e-48d2-9cb7-0ad5d38a1e5b" alt="로그인정보_안드로이드" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary-application/assets/97138841/f6afd72f-5598-400d-9b06-80222d9dae6a" alt="로그인정보_ios" width="260" height="580"/>
</div>

<br>

- 설정페이지 내 소셜 로그인 이메일 표시 적용
- 로그인한 본인 유저의 uuid에 대해서만 표시하도록 로직 적용

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

- 사용자 신고 기능 이슈가 완료되면, 신고 기능까지 함께 개발해서 1.1.1로 버전업을 진행할 예정입니다.
- 버전업 진행과 함께 애플 심사도 올릴 것으로 예상하고 있습니다.

<br>
